### PR TITLE
Added: Compile switch to hide additional information in txt records.

### DIFF
--- a/src/mgos_dns_sd.c
+++ b/src/mgos_dns_sd.c
@@ -140,16 +140,24 @@ static void add_txt_record(const char *name, struct mg_dns_reply *reply,
   struct mg_dns_resource_record rr =
       make_dns_rr(MG_DNS_TXT_RECORD, RCLASS_IN_FLUSH);
   rdata->len = 0;
+
+  /*
+  * Compile switch that hides additional information
+  */
+  #ifndef MGOS_DNS_SD_HIDE_ADDITIONAL_INFO
   append_label(rdata, mg_mk_str("id"),
                mg_mk_str(mgos_sys_config_get_device_id()));
   append_label(rdata, mg_mk_str("fw_id"),
                mg_mk_str(mgos_sys_ro_vars_get_fw_id()));
   append_label(rdata, mg_mk_str("arch"),
                mg_mk_str(mgos_sys_ro_vars_get_arch()));
+  #endif // MGOS_DNS_SD_HIDE_ADDITIONAL_INFO
+
 /*
  * TODO(dfrank): probably improve hooks so that we can add functionality
  * here from the rpc-common
  */
+
 
 #if 0
   append_label(rdata, mg_mk_str("rpc"),


### PR DESCRIPTION
@cpq I created a PR that adds the option to define MGOS_DNS_SD_HIDE_ADDITIONAL_INFO which hides the fields [id,fw_id,arch] in txt records.