### PR TITLE
mDNS Goodbye packet

### DIFF
--- a/include/mgos_dns_sd.h
+++ b/include/mgos_dns_sd.h
@@ -26,6 +26,7 @@ extern "C" {
  * Return currently configure DNS-SD hostname.
  */
 const char *mgos_dns_sd_get_host_name(void);
+void mgos_dns_sd_send_goodbye_packet(void);
 
 #ifdef __cplusplus
 }

--- a/src/mgos_dns_sd.c
+++ b/src/mgos_dns_sd.c
@@ -348,7 +348,7 @@ static void dns_sd_send_goodbye_packet(struct mg_connection *c) {
   memset(&msg, 0, sizeof(msg));
   msg.flags = 0x8400;
   reply = mg_dns_create_reply(&mbuf1, &msg);
-  goodbye_packet(&reply, &mbuf2);
+  goodbye_packet(&reply, false /* naive_client */, &mbuf2);
   if (msg.num_answers > 0) {
     LOG(LL_INFO, ("sending goodbye packet, size %d", (int) reply.io->len));
     mg_dns_send_reply(c, &reply);


### PR DESCRIPTION
Extract from the RFC 6762 (Multicast DNS):
In the case of shared records, a host MUST send a "goodbye"
announcement with RR TTL zero (see Section 10.1, "Goodbye Packets")
for the old rdata, to cause it to be deleted from peer caches, before
announcing the new rdata.

@cpq I created a PR for the goodbye packet.