### PR TITLE
Added: Public method for advertising.

### DIFF
--- a/include/mgos_dns_sd.h
+++ b/include/mgos_dns_sd.h
@@ -26,6 +26,7 @@ extern "C" {
  * Return currently configure DNS-SD hostname.
  */
 const char *mgos_dns_sd_get_host_name(void);
+void mgos_dns_sd_advertise(void);
 
 #ifdef __cplusplus
 }

--- a/src/mgos_dns_sd.c
+++ b/src/mgos_dns_sd.c
@@ -333,6 +333,14 @@ static void dns_sd_net_ev_handler(int ev, void *evd, void *arg) {
   (void) evd;
 }
 
+void mgos_dns_sd_advertise(void) {
+  struct mg_connection *c = mgos_mdns_get_listener();
+  LOG(LL_DEBUG, ("mdns_listener %p", c));
+  if (c != NULL) {
+    dns_sd_advertise(c);
+  }
+}
+
 const char *mgos_dns_sd_get_host_name(void) {
   return s_host_name;
 }


### PR DESCRIPTION
 This may be used in case of txt records that are changing during runtime.

The perfect (cleanest) solution would be to register a for configuration change events and then automatically advertise. But I didn't figure out how to do this.

@cpq This will be my last PR for mDNS.