### PR TITLE
add dns_sd.adv_only setting, to only join multicast group is enabled

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -11,6 +11,7 @@ includes:
 config_schema:
   - ["dns_sd", "o", {title: "DNS-SD service discovery"}]
   - ["dns_sd.enable", "b", false, {title: "Enable service discovery"}]
+  - ["dns_sd.adv_only", "b", false, {title: "Only advertise, do not join multicast group"}]
   - ["dns_sd.host_name", "s", "mOS-??????", {title: "DNS-SD host name. '?' chars will be expanded with MAC address hex digits. If not set, uses device.id"}]
   - ["dns_sd.txt", "s", "", {title: "Extra comma-separated key=value pairs to put into the TXT service record"}]
   - ["dns_sd.ttl", "i", 120, {title: "Time-to-live in seconds"}]

--- a/src/mongoose/mgos_mdns.c
+++ b/src/mongoose/mgos_mdns.c
@@ -99,7 +99,9 @@ bool mgos_mdns_init(void) {
   s_listening_mdns_conn->sa.sin.sin_port = htons(5353);
   inet_aton(MDNS_MCAST_GROUP, &s_listening_mdns_conn->sa.sin.sin_addr);
 
-  mgos_mdns_hal_join_group(MDNS_MCAST_GROUP);
+  if( ! mgos_sys_config_get_dns_sd_adv_only() ){
+    mgos_mdns_hal_join_group(MDNS_MCAST_GROUP);
+  }
 
   return true;
 }

--- a/src/mongoose/mgos_mdns.c
+++ b/src/mongoose/mgos_mdns.c
@@ -99,7 +99,7 @@ bool mgos_mdns_init(void) {
   s_listening_mdns_conn->sa.sin.sin_port = htons(5353);
   inet_aton(MDNS_MCAST_GROUP, &s_listening_mdns_conn->sa.sin.sin_addr);
 
-  if( ! mgos_sys_config_get_dns_sd_adv_only() ) {
+  if (!mgos_sys_config_get_dns_sd_adv_only()) {
     mgos_mdns_hal_join_group(MDNS_MCAST_GROUP);
   }
 

--- a/src/mongoose/mgos_mdns.c
+++ b/src/mongoose/mgos_mdns.c
@@ -99,7 +99,7 @@ bool mgos_mdns_init(void) {
   s_listening_mdns_conn->sa.sin.sin_port = htons(5353);
   inet_aton(MDNS_MCAST_GROUP, &s_listening_mdns_conn->sa.sin.sin_addr);
 
-  if( ! mgos_sys_config_get_dns_sd_adv_only() ){
+  if( ! mgos_sys_config_get_dns_sd_adv_only() ) {
     mgos_mdns_hal_join_group(MDNS_MCAST_GROUP);
   }
 


### PR DESCRIPTION
As discussed in #6 this adds a new setting of `dns_sd.adv_only` that will only join the multicast group (to respond to queries) when the value is `false` (default), otherwise it will not.

Fixes #6 